### PR TITLE
Change component name to normalize-scss

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "normalize.scss",
+    "name": "normalize-scss",
     "version": "2.1.2",
     "author": ["Nicolas Gallagher", "Bo-Yi Wu"],
     "main": ["_normalize.scss"],

--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
-    "name": "normalize.scss",
+    "name": "normalize-scss",
     "version": "2.1.2",
     "author": ["Nicolas Gallagher", "Bo-Yi Wu"],
     "styles": ["_normalize.scss"]


### PR DESCRIPTION
I've changed the name of the component from normalize.scss to normalize-scss.

The old name caused Bower to save this component with its old name. Bower also has a component in its repo called "normalize.scss". So when installing all dependencies of a project via `bower install` Bower tries to install the wrong component.
In order to prevent this behavior I suggest changing the name in the bower.json file. For consistency I also suggest to rename it in component.json.
