### PR TITLE
adds default flag, so users can set it from outside the file

### DIFF
--- a/_normalize.scss
+++ b/_normalize.scss
@@ -7,7 +7,7 @@
  * Set to false if you want to drop support for IE6 and IE7
  */
 
-$legacy_browser_support: false;
+$legacy_browser_support: false !default;
 
 /* ==========================================================================
    HTML5 display definitions


### PR DESCRIPTION
Hi @appleboy!

If you add the `!default` flag to your variables, developers are able to set this variable from outside the file, so they don't have to meddle with the source of the component [this article on Sass components for details](see (http://fettblog.eu/blog/2014/01/13/manageable-sass-components/). 

Would be great if you could add it :-)
