### PR TITLE
Remove settings comments from generated CSS file

### DIFF
--- a/_normalize.scss
+++ b/_normalize.scss
@@ -1,11 +1,10 @@
-/* ==========================================================================
-   Normalize.scss settings
-   ========================================================================== */
-/**
- * Includes legacy browser support IE6/7
- *
- * Set to false if you want to drop support for IE6 and IE7
- */
+// ==========================================================================
+// Normalize.scss settings
+// ==========================================================================
+//
+// Includes legacy browser support IE6/7
+//
+// Set to false if you want to drop support for IE6 and IE7
 
 $legacy_browser_support: false !default;
 


### PR DESCRIPTION
Replaces the kind of comments used to describe the `$legacy_browser_support` setting so that they are automatically removed from the final CSS file (since SASS automatically strips `//`-style comments when processing).

Currently, these comments about settings can end up in the final CSS, depending on the chosen output style.
